### PR TITLE
update(domains): Update domainsets for loop

### DIFF
--- a/letsencrypt/domains.sls
+++ b/letsencrypt/domains.sls
@@ -35,7 +35,7 @@
     - require:
       - file: {{ check_cert_cmd }}
 
-{% for setname, domainlist in letsencrypt.domainsets.items() %}
+{% for setname, domainlist in letsencrypt.get('domainsets', {}).items() %}
 
 # domainlist[0] represents the "CommonName", and the rest
 # represent SubjectAlternativeNames


### PR DESCRIPTION
using letsencrypt.get('domainsets', {}).items() will prevent the state from failing if no domainsets are defined. 

This is particularly useful for environments where letsencrypt can be included in the top file for a group of servers where only a few of them have domainsets defined. The servers that don't have domainsets defined will not fail to run scheduled highstates.